### PR TITLE
Update the bootstrap script to run a Django application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ dmypy.json
 
 # Vagrant
 .vagrant/
+
+# bootstrap.sh
+nohup.out
+
+# Django
+db.sqlite3

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,3 +5,11 @@
 # Install Pipenv, the -n option makes sudo fail instead of asking for a
 # password if we don’t have sufficient privileges to run it
 sudo -n dnf install -y pipenv
+
+cd /vagrant
+# Install dependencies with Pipenv
+pipenv sync --dev
+
+# run our app. Nohup and "&" are used to let the setup script finish
+# while our app stays up. The app logs will be collected in nohup.out
+nohup pipenv run python manage.py runserver 0.0.0.0:8000 &


### PR DESCRIPTION
The boostrap.sh script now installs Python dependencies and runs the Django server. 
After running "vagrant up" the website can be accessed locally
    (provided the Vagrant box doesn't already exist - to review this PR, run "vagrant destroy" first if it does).

.gitignore was updated accordingly.
Note: "db.sqlite3" was also added to .gitignore, since it is created by Django as part of the script.
          The task to add this change appears in the website part of the challenge (Part 5), 
          but I think it logically belongs in this PR. 

--- IMPORTANT ---
This PR is based on an unmerged branch (PR #13), that may be amended in the future.
It may require a rebase before it can be merged.

Closes #8.