### PR TITLE
Automating model registration to admin site

### DIFF
--- a/pickATrip_django_apps/admin.py
+++ b/pickATrip_django_apps/admin.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.contrib import admin
 from commenting_system.models import Comment
 
@@ -12,3 +13,21 @@ class CommentAdmin(admin.ModelAdmin):
 
     def approve_comments(self, request, queryset):
         queryset.update(active=True)
+
+
+# for viewing models registration fields
+class ListAdminMixin(object):
+    def __init__(self, general_model, admin_site):
+        self.list_display = [
+            field.name for field in general_model._meta.fields]
+        super(ListAdminMixin, self).__init__(general_model, admin_site)
+
+
+# Register all other models automatically - should stay last in file.
+models = apps.get_models()
+for model in models:
+    admin_class = type('AdminClass', (ListAdminMixin, admin.ModelAdmin), {})
+    try:
+        admin.site.register(model, admin_class)
+    except admin.sites.AlreadyRegistered:
+        pass


### PR DESCRIPTION
- Added [admin.py][1] file to automate the process of registering models to the admin site and ease the DB tables interaction through the admin interface, and providing columns display for each model field.

will be conflicted with PR #52 (related to issue #46)
closes #60 
