### PR TITLE
Black settings and CI 

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,17 @@
+name: Black
+
+on: [push, pull_request]
+
+jobs: 
+  Black:
+    runs-on: ubuntu-latest
+    container: fedora:32
+    steps:
+      - name: Install Pipenv and Git
+        run: dnf install -y pipenv git 
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup environment
+        run: pipenv sync --dev 
+      - name: Run Black
+        run: pipenv run black . --check --skip-string-normalization

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 flake8 = "*"
 pytest = "*"
 pytest-django = "*"
+black = "*"
 
 [packages]
 django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b952805deea7f54d74589003cf982e350c4eb2a70a82ff7bdc8ae8a29335d2dc"
+            "sha256": "b82419bca71a05874701bb3840a61cd7198fd533c9f11470897a33bb13425559"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -94,12 +94,34 @@
         }
     },
     "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
+        },
         "attrs": {
             "hashes": [
                 "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
                 "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
             "version": "==20.3.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:2db7040bbbbaa46247bfcc05c6efdebd7ebe50c1c3ca745ca6e0f6776438c96c",
+                "sha256:915d916c48646dbe8040d5265cff7111421a60a3dfe7f7e07273176a57c24a34"
+            ],
+            "index": "pypi",
+            "version": "==21.4b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:06b3a46da3b40f4bbe19b8ea5ba9a34e7925913a9b51608ff0c1d78ef0b814b4",
+                "sha256:7340a8666a3e2eff5f2ee778c2d06b606ce9891a61b2ee315e0a3994ffd2226a"
+            ],
+            "version": "==8.0.0rc1"
         },
         "flake8": {
             "hashes": [
@@ -123,6 +145,13 @@
             ],
             "version": "==0.6.1"
         },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
         "packaging": {
             "hashes": [
                 "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
@@ -130,12 +159,19 @@
             ],
             "version": "==20.9"
         },
+        "pathspec": {
+            "hashes": [
+                "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd",
+                "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"
+            ],
+            "version": "==0.8.1"
+        },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:265a94bf44ca13662f12fcd1b074c14d4b269a712f051b6f644ef7e705d6735f",
+                "sha256:467f0219e89bb5061a8429c6fc5cf055fa3983a0e68e84a1d205046306b37d9e"
             ],
-            "version": "==0.13.1"
+            "version": "==1.0.0.dev0"
         },
         "py": {
             "hashes": [
@@ -160,10 +196,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:1c6409312ce2ce2997896af5756753778d5f1603666dba5587804f09ad82ed27",
+                "sha256:f4896b4cc085a1f8f8ae53a1a90db5a86b3825ff73eb974dffee3d9e701007f4"
             ],
-            "version": "==2.4.7"
+            "version": "==3.0.0b2"
         },
         "pytest": {
             "hashes": [
@@ -180,6 +216,52 @@
             ],
             "index": "pypi",
             "version": "==4.2.0"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5",
+                "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79",
+                "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31",
+                "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500",
+                "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11",
+                "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14",
+                "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3",
+                "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439",
+                "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c",
+                "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82",
+                "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711",
+                "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093",
+                "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a",
+                "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb",
+                "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8",
+                "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17",
+                "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000",
+                "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d",
+                "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480",
+                "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc",
+                "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0",
+                "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9",
+                "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765",
+                "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e",
+                "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a",
+                "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07",
+                "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f",
+                "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac",
+                "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7",
+                "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed",
+                "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968",
+                "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7",
+                "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2",
+                "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4",
+                "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87",
+                "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8",
+                "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10",
+                "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29",
+                "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605",
+                "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6",
+                "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"
+            ],
+            "version": "==2021.4.4"
         },
         "toml": {
             "hashes": [

--- a/Post/migrations/0001_initial.py
+++ b/Post/migrations/0001_initial.py
@@ -7,14 +7,21 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
             name='post',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('nameOfPoster', models.CharField(max_length=100)),
                 ('nameOfLocation', models.CharField(max_length=100)),
                 ('photoURL', models.TextField()),

--- a/Post/migrations/0002_test_data.py
+++ b/Post/migrations/0002_test_data.py
@@ -20,9 +20,17 @@ class Migration(migrations.Migration):
         p2_Description = 'Beautiful place.'
 
         with transaction.atomic():
-            Post(nameOfPoster=p1_Author, nameOfLocation=p1_Place, photoURL=p1_URL, Description=p1_Description).save()
-            Post(nameOfPoster=p2_Author, nameOfLocation=p2_Place, photoURL=p2_URL, Description=p2_Description).save()
+            Post(
+                nameOfPoster=p1_Author,
+                nameOfLocation=p1_Place,
+                photoURL=p1_URL,
+                Description=p1_Description,
+            ).save()
+            Post(
+                nameOfPoster=p2_Author,
+                nameOfLocation=p2_Place,
+                photoURL=p2_URL,
+                Description=p2_Description,
+            ).save()
 
-    operations = [
-        migrations.RunPython(generate_data)
-    ]
+    operations = [migrations.RunPython(generate_data)]

--- a/Post/tests.py
+++ b/Post/tests.py
@@ -1,13 +1,14 @@
 from Post.models import Post
 
 
-class TestPost():
-
+class TestPost:
     def test_post_creation(self):
 
-        post1 = Post(nameOfPoster='Shoval',
-                     nameOfLocation='The Dead Sea',
-                     photoURL='www.testPost.com',
-                     Description='beautiful place')
+        post1 = Post(
+            nameOfPoster='Shoval',
+            nameOfLocation='The Dead Sea',
+            photoURL='www.testPost.com',
+            Description='beautiful place',
+        )
 
         assert str(post1) == "Shoval traveled The Dead Sea and wrote: beautiful place"

--- a/Post/views.py
+++ b/Post/views.py
@@ -33,13 +33,20 @@ def post_detail(request, post_id):
             comment_form = CommentForm()
     else:
         comment_form = CommentForm()
-    return render(request, 'Post/post_detail.html', {'post': post,
-                                                     'comments': comments,
-                                                     'new_comment': new_comment,
-                                                     'comment_form': comment_form,
-                                                     'label_to_badge_type': {"Recommended": "bg-success",
-                                                                             "Quiet": "bg-secondary",
-                                                                             "Crowded": "bg-warning",
-                                                                             "Chance to meet": "bg-primary",
-                                                                             "Want to go": "bg-info"}
-                                                     })
+    return render(
+        request,
+        'Post/post_detail.html',
+        {
+            'post': post,
+            'comments': comments,
+            'new_comment': new_comment,
+            'comment_form': comment_form,
+            'label_to_badge_type': {
+                "Recommended": "bg-success",
+                "Quiet": "bg-secondary",
+                "Crowded": "bg-warning",
+                "Chance to meet": "bg-primary",
+                "Want to go": "bg-info",
+            },
+        },
+    )

--- a/commenting_system/migrations/0001_initial.py
+++ b/commenting_system/migrations/0001_initial.py
@@ -18,23 +18,49 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Comment',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
                 ('body', models.TextField()),
                 ('created_on', models.DateTimeField(auto_now_add=True)),
-                ('label', models.CharField(blank=True, choices=[('Recommended', 'Recommended'),
-                                                                ('Want to go', 'Want To Go'),
-                                                                ('Quiet', 'Quiet Place'),
-                                                                ('Crowded', 'Crowded Place'),
-                                                                ('Chance to meet', 'Chance To Meet')],
-                                           max_length=20,
-                                           null=True)),
+                (
+                    'label',
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ('Recommended', 'Recommended'),
+                            ('Want to go', 'Want To Go'),
+                            ('Quiet', 'Quiet Place'),
+                            ('Crowded', 'Crowded Place'),
+                            ('Chance to meet', 'Chance To Meet'),
+                        ],
+                        max_length=20,
+                        null=True,
+                    ),
+                ),
                 ('active', models.BooleanField(default=False)),
-                ('post', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE,
-                                           related_name='comments',
-                                           to='Post.post')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE,
-                                           related_name='comments',
-                                           to=settings.AUTH_USER_MODEL)),
+                (
+                    'post',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='comments',
+                        to='Post.post',
+                    ),
+                ),
+                (
+                    'user',
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name='comments',
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
             options={
                 'ordering': ['-created_on'],

--- a/commenting_system/migrations/0002_test_data.py
+++ b/commenting_system/migrations/0002_test_data.py
@@ -13,18 +13,29 @@ class Migration(migrations.Migration):
         from commenting_system.models import Comment
 
         users_list = [
-            User.objects.create_user('Test-user-comments1', 'Test3@gmail.com', 'password777'),
-            User.objects.create_user('Test-user-comments2', 'Test4@gmail.com', 'password222')
+            User.objects.create_user(
+                'Test-user-comments1', 'Test3@gmail.com', 'password777'
+            ),
+            User.objects.create_user(
+                'Test-user-comments2', 'Test4@gmail.com', 'password222'
+            ),
         ]
 
-        body_comments_list = [
-            ('First comment test'),
-            ('Second comment test')
-        ]
+        body_comments_list = [('First comment test'), ('Second comment test')]
 
         Post_list = [
-            Post(nameOfPoster='Leead', nameOfLocation='Eilat', photoURL='test_1.com', Description='Perfect!'),
-            Post(nameOfPoster='Shoval', nameOfLocation='Tel-Aviv', photoURL='test_2.com', Description='This is nice'),
+            Post(
+                nameOfPoster='Leead',
+                nameOfLocation='Eilat',
+                photoURL='test_1.com',
+                Description='Perfect!',
+            ),
+            Post(
+                nameOfPoster='Shoval',
+                nameOfLocation='Tel-Aviv',
+                photoURL='test_2.com',
+                Description='This is nice',
+            ),
         ]
 
         test_data = list(zip(users_list, body_comments_list, Post_list))
@@ -34,9 +45,8 @@ class Migration(migrations.Migration):
             for user, body, post in test_data:
                 user.save()
                 post.save()
-                Comment(user=user, body=body, post=post,
-                        label="Recommended", active=True).save()
+                Comment(
+                    user=user, body=body, post=post, label="Recommended", active=True
+                ).save()
 
-    operations = [
-        migrations.RunPython(generate_data)
-    ]
+    operations = [migrations.RunPython(generate_data)]

--- a/commenting_system/models.py
+++ b/commenting_system/models.py
@@ -12,13 +12,19 @@ class Comment(models.Model):
         CHANCE_TO_MEET = "Chance to meet"
 
     post = models.ForeignKey(
-        Post, on_delete=models.CASCADE, related_name='comments', null=False)
-    user = models.ForeignKey(settings.AUTH_USER_MODEL,
-                             on_delete=models.CASCADE, related_name='comments', null=False)
+        Post, on_delete=models.CASCADE, related_name='comments', null=False
+    )
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='comments',
+        null=False,
+    )
     body = models.TextField()
     created_on = models.DateTimeField(auto_now_add=True, null=False)
-    label = models.CharField(choices=Label.choices,
-                             max_length=20, blank=True, null=True)
+    label = models.CharField(
+        choices=Label.choices, max_length=20, blank=True, null=True
+    )
     active = models.BooleanField(default=False, null=False)
 
     class Meta:

--- a/picATrip/urls.py
+++ b/picATrip/urls.py
@@ -27,8 +27,16 @@ urlpatterns = [
     path('', views.homepage, name='homepage'),
     path('about/', views.about, name='about'),
     path('register/', user_views.register, name='register'),
-    path('login/', auth_views.LoginView.as_view(template_name='users/login.html'), name='login'),
-    path('logout/', auth_views.LogoutView.as_view(template_name='users/logout.html'), name='logout'),
+    path(
+        'login/',
+        auth_views.LoginView.as_view(template_name='users/login.html'),
+        name='login',
+    ),
+    path(
+        'logout/',
+        auth_views.LogoutView.as_view(template_name='users/logout.html'),
+        name='logout',
+    ),
     path('profile/', user_views.profile, name='profile'),
     path('postList/', include('Post.urls'), name='postList'),
 ]

--- a/pickATrip_django_apps/admin.py
+++ b/pickATrip_django_apps/admin.py
@@ -18,8 +18,7 @@ class CommentAdmin(admin.ModelAdmin):
 # for viewing models registration fields
 class ListAdminMixin(object):
     def __init__(self, general_model, admin_site):
-        self.list_display = [
-            field.name for field in general_model._meta.fields]
+        self.list_display = [field.name for field in general_model._meta.fields]
         super(ListAdminMixin, self).__init__(general_model, admin_site)
 
 

--- a/tests/001_tests.py
+++ b/tests/001_tests.py
@@ -14,5 +14,5 @@ class TestProfile:
             ('Test-user-comments1'),
             ('Test-user-comments2'),
             ('Test-user-profile3'),
-            ('Test-user-profile4')
+            ('Test-user-profile4'),
         ]

--- a/users/apps.py
+++ b/users/apps.py
@@ -5,4 +5,4 @@ class UsersConfig(AppConfig):
     name = 'users'
 
     def ready(self):
-        import users.signals # noqa
+        import users.signals  # noqa

--- a/users/migrations/0001_initial.py
+++ b/users/migrations/0001_initial.py
@@ -17,12 +17,27 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Profile',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('image', models.ImageField(default='default.jpg', upload_to='profile_pics')),
+                (
+                    'id',
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'image',
+                    models.ImageField(default='default.jpg', upload_to='profile_pics'),
+                ),
                 ('dob', models.DateField(blank=True, null=True)),
-                ('user', models.OneToOneField(
-                    on_delete=django.db.models.deletion.CASCADE,
-                    to=settings.AUTH_USER_MODEL)),
+                (
+                    'user',
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
         ),
     ]

--- a/users/migrations/0002_test_data.py
+++ b/users/migrations/0002_test_data.py
@@ -10,8 +10,12 @@ class Migration(migrations.Migration):
 
     def generate_data(apps, schema_editor):
         users_list = [
-            User.objects.create_user('Test-user-profile3', 'Test@gmail.com', 'password777'),
-            User.objects.create_user('Test-user-profile4', 'Test2@gmail.com', 'password222')
+            User.objects.create_user(
+                'Test-user-profile3', 'Test@gmail.com', 'password777'
+            ),
+            User.objects.create_user(
+                'Test-user-profile4', 'Test2@gmail.com', 'password222'
+            ),
         ]
 
         with transaction.atomic():

--- a/users/views.py
+++ b/users/views.py
@@ -10,7 +10,10 @@ def register(request):
         if form.is_valid():
             form.save()
             username = form.cleaned_data.get('username')
-            messages.success(request, f' {username}, Your account has been created! You are now able to log in')
+            messages.success(
+                request,
+                f' {username}, Your account has been created! You are now able to log in',
+            )
             return redirect('login')
     else:
         form = UserRegistrationForm()


### PR DESCRIPTION
- Adding black formatting check to the workflows of github to reduce amount of time of formatting code manually and dealing with human errors.
- Modifying  Pipfile to consist of black settings to support running locally the command of black for formatting check: 
1. vagrant ssh 
2. cd /vagrant
3. pipenv run python -m black . --check --skip-string-normalization
4. (For formatting the files repeat 1 to 3 and eliminate the --check argument)

closes #78  
closes #79

BE AWARE: Apparently, Black formatting prefer double quote than single quote, couldn't find a simple way to make it ignore single quotes, so the formatting files are mostly as a result of this.